### PR TITLE
Pass style name to Attachment#exists?

### DIFF
--- a/lib/paperclip/storage/multiple.rb
+++ b/lib/paperclip/storage/multiple.rb
@@ -36,7 +36,7 @@ module Paperclip
       ##
       # This defaults to the filesystem version, since it's a lot faster than querying s3.
       def exists?(style_name = default_style)
-        filesystem.exists?
+        filesystem.exists?(style_name)
       end
 
       ##


### PR DESCRIPTION
The version of #exists? used in Multiple completely drops the style name argument when checking for a local file - it only ever checks for the original file.  This can lead to the system thinking that all styles are
persisted when actually only the original style is.
